### PR TITLE
Potential fix for code scanning alert no. 16: Information exposure through an exception

### DIFF
--- a/geoip_proxy.py
+++ b/geoip_proxy.py
@@ -79,7 +79,8 @@ def get_geoip_update():
     try:
         return jsonify({"error": "IP address not found"}), 404
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route(rule='/geoip', methods=['GET'])
@@ -97,7 +98,8 @@ def get_geoip_info():
         else:
             return jsonify({"error": "IP address not found"}), 404
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route(rule='/geoipcity', methods=['GET'])
@@ -117,7 +119,8 @@ def get_geoip_city_info():
     except ValueError as e:
         return jsonify({"error": "Invalid value: " + str(e)}), 400
     except Exception as e:
-        return jsonify({"error": "Internal server error: " + str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({"error": "Internal server error"}), 500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/nqdev-storage/nqdev-geoip/security/code-scanning/16](https://github.com/nqdev-storage/nqdev-geoip/security/code-scanning/16)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `traceback` module to capture the stack trace.
2. Modify the exception handling blocks to log the stack trace and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
