### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through an exception

### DIFF
--- a/geoip_proxy.py
+++ b/geoip_proxy.py
@@ -117,7 +117,8 @@ def get_geoip_city_info():
         else:
             return jsonify({"error": "IP address not found"}), 404
     except ValueError as e:
-        return jsonify({"error": "Invalid value: " + str(e)}), 400
+        logging.error("ValueError occurred: %s", str(e))
+        return jsonify({"error": "Invalid value provided"}), 400
     except Exception as e:
         logging.error("Exception occurred", exc_info=True)
         return jsonify({"error": "Internal server error"}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/nqdev-storage/nqdev-geoip/security/code-scanning/17](https://github.com/nqdev-storage/nqdev-geoip/security/code-scanning/17)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

**Steps to fix:**
1. Modify the exception handling block on line 119-121 to log the detailed error message using `logging.error`.
2. Return a generic error message to the user instead of including the exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
